### PR TITLE
Add Huawei Honor 9 Lite (EMUI 8.0.0)

### DIFF
--- a/_vendors/huawei.md
+++ b/_vendors/huawei.md
@@ -33,6 +33,10 @@ Huawei P20:
 
 * *Phone settings > Battery > App launch* and then set your app to “Manage manually” and make sure everything is turned on.
 
+Huawei Honor 9 Lite:
+
+* *Phone settings > Battery > Launch* and then set your app to “Manage manually” and make sure everything is turned on.
+
 '
 
 developer_solution: "No known solution on developer end"


### PR DESCRIPTION
Settings are almost the same as Huawei P20, except that "App Launch" is just called "Launch".