### PR TITLE
Method to avoid OnePlus Phones to revert the battery optimisation settings

### DIFF
--- a/_vendors/oneplus.md
+++ b/_vendors/oneplus.md
@@ -29,6 +29,13 @@ Also try:
 Also disable **Settings > Battery > Battery optimization > (three dots) > Enhanced optimization**. This option may also be called **Advanced optimisation**.
 '
 
+To avoid the system to automatically revert the **not optimized** setting, you must also lock the app into the 'Recent App' list. (solution described [here](https://forum.xda-developers.com/showpost.php?p=78588761&postcount=7))
+
+Start the app you want to "protect". Press the phone 'Recent app' button. Toggle the 'Lock' button on the upper right corner of the app.
+
+This will avoid the app to be killed in background and the 'Battery optimisation' setting to be reverted.
+
+
 developer_solution: "No known solution on the developer end"
 
 ---

--- a/_vendors/oneplus.md
+++ b/_vendors/oneplus.md
@@ -15,6 +15,11 @@ user_solution: 'Turn off **System Settings > Apps > Gear Icon > Special Access >
 
 > WARNING: Recently OnePlus phones started reverting this setting randomly for random apps. So if you set it to be **not optimized**, the next day it may be back to **optimized**. There is no workaround and you may have to check system settings every once in a while.<br>See [a bug report filed to OnePlus](https://forums.oneplus.com/threads/in-battery-optimisation-apps-are-getting-automatically-switched-from-not-optimised-to-optimised.849162/).
 
+To avoid the system to automatically revert the **not optimized** setting, you must also lock the app into the 'Recent App' list. (solution described [here](https://forum.xda-developers.com/showpost.php?p=78588761&postcount=7))
+
+Start the app you want to "protect". Press the phone 'Recent app' button. Toggle the 'Lock' button on the upper right corner of the app.
+
+This will avoid the app to be killed in background and the 'Battery optimisation' setting to be reverted.
 
 On some OnePlus phones there is also a thing called App Auto-Launch which essentially prevents apps from working in the background. Please disable it for your app.
 
@@ -28,13 +33,6 @@ Also try:
 
 Also disable **Settings > Battery > Battery optimization > (three dots) > Enhanced optimization**. This option may also be called **Advanced optimisation**.
 '
-
-To avoid the system to automatically revert the **not optimized** setting, you must also lock the app into the 'Recent App' list. (solution described [here](https://forum.xda-developers.com/showpost.php?p=78588761&postcount=7))
-
-Start the app you want to "protect". Press the phone 'Recent app' button. Toggle the 'Lock' button on the upper right corner of the app.
-
-This will avoid the app to be killed in background and the 'Battery optimisation' setting to be reverted.
-
 
 developer_solution: "No known solution on the developer end"
 


### PR DESCRIPTION
This pull request aim to describe how to prevent the OnePlus phones to revert the don't optimize battery settings. This should fixes #12 
I based my modification on the linked website described in the #12 issue.
