### PR TITLE
Raise card subtitle font-weight to 300 for readability

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -85,7 +85,7 @@ blockquote {
     // color: #888;
     min-height: 1em;
     font-size: 0.7em;
-    font-weight: 100;
+    font-weight: 300;
   }
 }
 .card-vendor {


### PR DESCRIPTION
![Screenshot_20200621_142654](https://user-images.githubusercontent.com/11722318/85217553-33fb5b80-b3cd-11ea-8907-e3910ff34102.png)

A `font-weight` of 100 is barely readable when the subtitle is as small as body text. Roboto 300 is a lot better, while still retaining the contrast between the subtitle (300) and the card heading (400).