### PR TITLE
Update example to use Kotlin + Coroutines over deprecated AsyncTask

### DIFF
--- a/_vendors/stock_android.md
+++ b/_vendors/stock_android.md
@@ -5,17 +5,17 @@ manufacturer:
   - google
 redirect_from: /vendors/stock_android.html
 explanation: "
-  On Pixels and Nexuses you have the least change something goes wrong with background processing, but still there are
+  On Pixels and Nexuses you have the least chance something goes wrong with background processing, but still there are
   several places to look at!
 
 
   Some use-cases are no more possible or paradoxically more battery consuming (e.g. gathering sensor data through sensor batching,see [Solution for developers](#dev-solution)) with the introduction of [Doze mode](https://developer.android.com/training/monitoring-device-state/doze-standby) in Android 6+ and you may need to opt the app out of battery optimizations to make it work properly.
 
 
-Also a serios doze mode bug in Android 6.0 even prevented foreground services to do their job (see [Solution for devs](#dev-solution) for workaround), but luckily this was fixed in 7.0.
+Also a serious doze mode bug in Android 6.0 that prevented foreground services from doing their intended job (see [Solution for devs](#dev-solution) for workaround), but luckily this was later fixed in 7.0.
 
 
-  After Android 8 users or even the system (Adaptive battery in Android 9) can decide to prevent your apps background processes from working and you may need to check the Background restrictions (or limits) option in your phone settings.
+  After Android 8, users or even the system (Adaptive battery in Android 9) can decide to prevent your app's background processes from working and you may need to check the Background restrictions (or limits) option in your phone settings.
 "
 
 

--- a/api.md
+++ b/api.md
@@ -92,41 +92,51 @@ scheme:
 }
 ````
 
-Android example (Java):
+Android example (Kotlin):
 ````
-new AsyncTask<Void, Void, String>() {
-    @Override
-    protected String doInBackground(Void... voids) {
-        try {
-            return ((JSONObject) new JSONTokener(
-                InputStreamUtil.read(new URL("https://dontkillmyapp.com/api/v2/"+Build.MANUFACTURER.toLowerCase().replaceAll(" ", "-")+".json").openStream())).nextValue()
-              ).getString("user_solution").replaceAll("\\[[Yy]our app\\]", context.getString(R.string.app_name));
-        } catch (Exception e) {
-            // This vendor is not in the DontKillMyApp list
+// Use this method in your ViewModel
+fun getDKMAData() {
+
+    viewModelScope.launch(Dispatchers.IO) {
+
+        val result = try {
+            val manufacturer = Build.MANUFACTURER.toLowerCase(Locale.ROOT).replace(" ", "-")
+            val url = URL("https://dontkillmyapp.com/api/v2/$manufacturer.json")
+            val json = JSONTokener(url.readText()).nextValue() as JSONObject?
+            json?.getString("user_solution")?.replace(Regex("\\[[Yy]our app\\]"), yourAppName)
+        } catch (e: Exception) {
+            // Vendor not present in the DontKillMyApp list
+            null
         }
-        return null;
+
+        withContext(Dispatchers.Main) {
+            when (result) {
+                null -> TODO("Handle lack of result")
+                else -> TODO("Pass back result to your UI here")
+            }
+        }
+
     }
+}
 
-    @Override
-    protected void onPostExecute(String result) {
-        if (result != null) {
-            WebView wv = new WebView(context);
-            wv.loadData(result, "text/html; charset=utf-8", "UTF-8");
-            wv.setWebViewClient(new WebViewClient() {
-                @Override
-                public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                    view.loadUrl(url);
-                    return true;
-                }
-            });
+// Use this method in your UI, Activity or Fragment
+fun showData(result: String) {
+    AlertDialog.Builder(context)
+        .setTitle("How to make my app work")
+        .setView(webview.loadDKMAData(result))
+        .setPositiveButton(android.R.string.ok, null)
+        .show()
+}
 
-            new AlertDialog.Builder(context)
-                    .setTitle("How to make my app work")
-                    .setView(wv).setPositiveButton(android.R.string.ok, null).show();
+fun WebView.loadDKMAData(result: String) {
+    loadData(result, "text/html; charset=utf-8", "UTF-8")
+    webViewClient = object : WebViewClient() {
+        override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+            loadUrl(url)
+            return true
         }
     }
-}.execute();
-
+}
 ````
 
 


### PR DESCRIPTION
As Android is now 'Kotlin first', this PR removes the outdated and deprecated use of AsyncTask in the example API documentation and replaces it with a Kotlin equivalent