### PR TITLE
Replace dead G+ link w Internet Archive capture

### DIFF
--- a/_vendors/stock_android.md
+++ b/_vendors/stock_android.md
@@ -79,7 +79,7 @@ Tips:
 ## Android 6.0
 
 
-A serious bug in Doze mode in Android 6.0 which we (authors of this site) reported to Google (Dianne Hackborn) during the 6.0 BETA does not allow foreground services to keep a wake lock every time an activity or a broadcast receiver kicks in, see [https://plus.google.com/u/0/+AndroidDevelopers/posts/94jCkmG4jff](https://plus.google.com/u/0/+AndroidDevelopers/posts/94jCkmG4jff) and search for Petr Nalevka and Dianne Hackborn.
+A serious bug in Doze mode in Android 6.0 which we (authors of this site) reported to Google (Dianne Hackborn) during the 6.0 BETA does not allow foreground services to keep a wake lock every time an activity or a broadcast receiver kicks in, see [https://plus.google.com/+AndroidDevelopers/posts/94jCkmG4jff](https://web.archive.org/web/20181030095832/https://plus.google.com/+AndroidDevelopers/posts/94jCkmG4jff) and search for Petr Nalevka and Dianne Hackborn.
 
 
 


### PR DESCRIPTION
Fortunately there seems to be at least 1 archive of this post daring to October 2018, and while the last G+ UI hides all comments by default, a relevant comment by Dianne Hackborn acknowledging and explaining the bug is visible in the capture.
Here it is for convenience :
https://web.archive.org/web/20181030095832/https://plus.google.com/+AndroidDevelopers/posts/94jCkmG4jff