### PR TITLE
Unihertz - add this vendor

### DIFF
--- a/_vendors/unihertz.md
+++ b/_vendors/unihertz.md
@@ -1,0 +1,21 @@
+---
+name: Unihertz
+manufacturer:
+  - unihertz
+award: 2
+position: 15
+redirect_from: /vendors/unihertz.html
+explanation: "
+
+On at least Unihertz's Atom L and Atom XL devices, there is a third-party background blocking application. It, combined with other default Android battery optimizations, can sneakily cause apps to not work as expected. Luckily, the steps to fix this are straightforward.
+"
+
+user_solution: "
+* Follow [other vendors](https://dontkillmyapp.com/general) optimization steps, such as enabling 'ignore optimizations,' for your app.
+* Go to **Settings > Intelligent assistance > App blocker**. Find your app, tap it.
+* Uncheck all settings, which include **Boot blocker**, **Start blocker**, **Background blocker**, and **Background cleanup**.
+"
+
+developer_solution: "No developer solution at the moment"
+
+---


### PR DESCRIPTION
I've recently had this issue on a Unihertz device, and would like others to be
aware of the vendor-specific fix.

Unihertz is a PRC-based company that makes niche devices such as a super tiny
Android 10 phone, a physical keyboard phone, and a highly ruggedized Android 10
phone with a walkie-talkie attachment. The total devices in the wild are low,
but the use cases are niche enough that I believe most Unihertz phone users will
run into issues with the similarly niche apps they'll be using.

FYI I wasn't sure what to put for award or position, so I made my best guess. 