### PR TITLE
Added new info about antivirus and apps not launching after startup

### DIFF
--- a/_vendors-content/huawei/user.md
+++ b/_vendors-content/huawei/user.md
@@ -92,7 +92,7 @@ Recently, Huawei incorporated Avast antivirus into their "Manager" app. If your 
 
 `adb shell pm uninstall -k --user 0 com.huawei.systemmanager`
 
-Note, that then you will not have acces to Battery Optimization setting. If yor apps don't launch after system startup, you can then uninstall:
+Note, that then you will not have acces to Battery Optimization setting, the Huawei storage cleaner app and other possible parts of the Manager app. If yor apps don't launch after system startup, you can then uninstall:
 
 `adb shell pm uninstall -k --user 0 com.huawei.iaware`
 

--- a/_vendors-content/huawei/user.md
+++ b/_vendors-content/huawei/user.md
@@ -86,6 +86,17 @@ If apps keep getting killed try running `adb shell pm stopservice hwPfwService`.
 
 We did not yet have this confirmed but it is possible you can alternatively just disable PowerGenie in *Phone settings > Apps*. This setting would need to be re-applied every time you reboot your device.
 
+#### SystemManager
+
+Recently, Huawei incorporated Avast antivirus into their "Manager" app. If your apps get reported as infected, it is possible to uninstall it:
+
+`adb shell pm uninstall -k --user 0 com.huawei.systemmanager`
+
+Note, that then you will not have acces to Battery Optimization setting. If yor apps don't launch after system startup, you can then uninstall:
+
+`adb shell pm uninstall -k --user 0 com.huawei.iaware`
+
+which removes the Huawei whitelist for apps which request "BOOT_COMPLETED" permission.
 
 <div class="caution-box">
 Please still follow the steps below - Huawei phones usually have multiple powersaving mechanisms.


### PR DESCRIPTION
Hi, we did some research why our research medical app which runs a foreground service gets afterwhile reported as "infected". We discovered that in some system update, Huawei added antivirus service into their Manager app. It, as is Huawei style, cannot be disabled so the only option is to uninstall the whole package. After that, our app suddenly wasnt starting after reboot, which was due to iaware service blocking everything, as the battery optimization setting was uninstalled with the systemmanager. So that can be solved by uninstalling the iaware app also. There was no discernable impact on system functions or behaviour. I thought someone might use that information so we would like to post it!
Cheers,
Tomas
