### PR TITLE
Correct typo and grammar in Motorola explanation.md

### DIFF
--- a/_vendors-content/motorola/explanation.md
+++ b/_vendors-content/motorola/explanation.md
@@ -5,4 +5,4 @@ manufacturer:
 ---
 
 
-Even on Motoroal phones, has been reported an increased amount of apps being killed in the background lately. Anyone having any details on this?
+Even on Motorola phones, there has been reported an increased amount of apps being killed in the background lately. Anyone having any details on this?


### PR DESCRIPTION
Fixed a typo ("Motoroal" to "Motorola") and improved the sentence structure for clarity.