### PR TITLE
Fix Xiami user.md front matter formatting 

### DIFF
--- a/_vendors-content/xiaomi/user.md
+++ b/_vendors-content/xiaomi/user.md
@@ -1,7 +1,7 @@
 ---
 manufacturer: 
     - xiaomi
-
+---
 ---
 
 ### App pinning / App locking


### PR DESCRIPTION


This PR fixes the YAML front matter in _vendors-content/xiaomi/user.md.

Added the missing closing --- after the manufacturer section.

Ensures the metadata block is valid and consistent with other vendor files.


This change improves Markdown rendering and maintains proper structure for the documentation.


---