### PR TITLE
Add ADB command for Shizuku API startup on Huawei devicesm

### DIFF
--- a/_vendors-content/huawei/user.md
+++ b/_vendors-content/huawei/user.md
@@ -1,4 +1,4 @@
----
+---adb shell sh /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh
 manufacturer:
     - huawei
 


### PR DESCRIPTION
Added adb command for starting Shizuku API on Huawei devices.adb shell sh /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh