### PR TITLE
Insert shareable badge link in Motorola user documentation

### DIFF
--- a/_vendors-content/motorola/user.md
+++ b/_vendors-content/motorola/user.md
@@ -1,4 +1,4 @@
----
+<a href="https://dontkillmyapp.com/motorola"><img id="badge-shareable" width="306px" src="https://dontkillmyapp.com/badge/motorola3.svg"></a>---
 manufacturer: 
     - motorola
 


### PR DESCRIPTION
Added a shareable badge link for Motorola users.