### PR TITLE
Correct contact information punctuation in LICENCE

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -392,4 +392,4 @@ understandings, or agreements concerning use of licensed material. For
 the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
-Creative Commons may be contacted at creativecommons.org.
+Creative Commons may be contacted at creativecommons.org


### PR DESCRIPTION
Fix missing period at the end of the contact information.